### PR TITLE
Ensure that job resolution is checked

### DIFF
--- a/server/imports/actions/execute/process.js
+++ b/server/imports/actions/execute/process.js
@@ -2,7 +2,7 @@ import { Utilities } from '../../utilities'
 import { toolbelt } from './toolbelt.js'
 
 const process = async function (doc, callback) {
-	// Goals: 
+	// Goals:
 	// 1- Execute the job
 	// 2- Update the document in database
 	// 3- Capture the result (if any)
@@ -14,17 +14,18 @@ const process = async function (doc, callback) {
     // const jobResult = Promise.await(Promise.resolve(res))
     // const jobResult = await res()
 		const jobResult = await Utilities.registry.data[doc.name].apply(Toolbelt, doc.arguments)
+		await Toolbelt.checkForResolution(jobResult);
 
 		if (typeof callback === "function") {
 			return callback(undefined, jobResult);
 		} else {
 			return jobResult;
 		}
-	} catch (error) {		
+	} catch (error) {
 		const failure = await Toolbelt.failure(error.stack);
-		
+
 		Utilities.logger(`Job failed to run due to code error: ${doc.name}`)
-		console.log(error);
+		console.error(error);
 
 		if (typeof callback === "function") {
 			return callback(error, undefined);


### PR DESCRIPTION
It appears that during the transition work we lost job resolution check which would result in endlessly generating and re-running the same job on each tick of the scheduler. This commit returns it and hence ensures that successful jobs get mark as such.